### PR TITLE
updating p2-theme-core

### DIFF
--- a/web/themes/dashing/config.yml
+++ b/web/themes/dashing/config.yml
@@ -27,7 +27,6 @@ js:
   enabled: false
 patternLab:
   enabled: true
-  engine: php-twig
   src:
     root: pattern-lab/
     source: pattern-lab/source/

--- a/web/themes/dashing/package.json
+++ b/web/themes/dashing/package.json
@@ -17,7 +17,7 @@
     "gulp": "^3.9.1",
     "gulp-help": "^1.6.1",
     "js-yaml": "^3.5.5",
-    "p2-theme-core": "^6.5.0",
+    "p2-theme-core": "^7.0.1",
     "singularitygs": "^1.7.0"
   }
 }


### PR DESCRIPTION
v6.x pulled in PL node as a dep and v7 doesn't; so `npm install`s should be faster.
