### PR TITLE
using composer run-script for drupal server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When it asks if you want to merge or replace stuff, select merge.
 
 In two Terminal tabs, run:
 
-1. Run `../vendor/bin/drupal server` in `web/`
+1. Run `composer run-script server`
 1. Run `npm start` in `web/themes/dashing/`
 
 ### Drupal Credentials

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         ]
     },
     "scripts": {
+        "server": "drupal server --root=web/",
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::buildScaffold",

--- a/scripts/site-setup.sh
+++ b/scripts/site-setup.sh
@@ -35,5 +35,5 @@ echo ""
 echo "Compiling..."
 npm run compile
 echo "All done; login is 'admin:admin'."
-echo "Drupal Server: run '../vendor/bin/drupal server' in 'web/' "
+echo "Drupal Server: run 'composer run-script server'"
 echo "Pattern Lab Server: run 'npm start' in 'web/themes/dashing/' "


### PR DESCRIPTION
Now we can `composer run-script server` instead of `cd web && ../vendor/bin/drupal server` :)
